### PR TITLE
ignore css rule when it has 'ignore rem2px' comment in first node

### DIFF
--- a/tasks/px_to_rem.js
+++ b/tasks/px_to_rem.js
@@ -30,6 +30,12 @@ module.exports = function(grunt) {
       var postcss = require('postcss');
       var processor = postcss(function(css) {
         css.eachRule(function(rule, i) {
+          /*
+            ignore css rule when it has 'ignore rem2px' comment in first node
+           */
+          if(rule.nodes[0].type === 'comment' && rule.nodes[0].text === 'ignore rem2px'){
+            return;
+          }
           /**
            * Find elements that has fallback allready
            */


### PR DESCRIPTION
Sometime i want to ignore some class to stop converting px to rem;
for example:

``` css
.icon{
    /* ignore rem2px */
    width: 24px;
    height: 24px;
    background: url(/images//myicon.png) no-repeat;
}
.my-icon-1{
   /* ignore rem2px */
  background-position: 0 -402px;
}
```

the .icon class has width and height property and i don't want it convert to rem for some reason. But i still want another class do this. so i  i put `ignore rem2px` comment to first css node; then icon and my-icon-1 won't convert rem to px;
